### PR TITLE
Fix to support the paperclip timestamp param which doesn't have a value.

### DIFF
--- a/lib/dynamic_paperclip/attachment.rb
+++ b/lib/dynamic_paperclip/attachment.rb
@@ -42,7 +42,7 @@ module DynamicPaperclip
 
       url = url(style_name)
 
-      delimiter_char = url.match(/\?.+=/) ? '&' : '?'
+      delimiter_char = url.match(/\?/) ? '&' : '?'
 
       "#{url}#{delimiter_char}s=#{UrlSecurity.generate_hash(style_name)}"
     end


### PR DESCRIPTION
Without the fix it generates a link with 2 question marks (?)

Ex: /dynamic_10x10/test.png?1498760424?s=c3ac6269a728f8e9a8d625ef84455a082bdd3bbf