### PR TITLE
When the filename is wrong, return a 404.

### DIFF
--- a/lib/dynamic_paperclip/attachment_style_generator.rb
+++ b/lib/dynamic_paperclip/attachment_style_generator.rb
@@ -18,6 +18,11 @@ module DynamicPaperclip
           id = id_from_partition(match[:id])
           attachment = klass.find(id).send(name)
 
+          # When the filename is wrong, return a 404
+          if attachment.original_filename != URI.unescape(match[:filename])
+            return [404, {}, []]
+          end
+
           # The definition will be escaped twice in the URL, so we need to unescape it once.
           # We should always reference dynamic style names after escaping once - that's how they reside on the FS.
           style_name = StyleNaming.dynamic_style_name_from_definition(CGI.unescape(match[:definition]), false)

--- a/lib/dynamic_paperclip/attachment_style_generator.rb
+++ b/lib/dynamic_paperclip/attachment_style_generator.rb
@@ -19,7 +19,7 @@ module DynamicPaperclip
           attachment = klass.find(id).send(name)
 
           # When the filename is wrong, return a 404
-          if attachment.original_filename != URI.unescape(match[:filename])
+          if !attachment.exists? || attachment.original_filename != URI.unescape(match[:filename])
             return [404, {}, []]
           end
 

--- a/test/unit/attachment_style_generator_test.rb
+++ b/test/unit/attachment_style_generator_test.rb
@@ -19,7 +19,7 @@ class DynamicPaperclip::AttachmentStyleGeneratorTest < MiniTest::Unit::TestCase
     @app = stub('Application', :call => [200, {}, ''])
 
     @foo = stub('foo')
-    @attachment = stub('image attachment', :path => File.join(FIXTURES_DIR, 'rails.png'), :content_type => 'image/jpeg')
+    @attachment = stub('image attachment', :path => File.join(FIXTURES_DIR, 'rails.png'), :original_filename => 'rails.png', :content_type => 'image/jpeg')
     @attachment.stubs(:exists?).returns(true)
 
     Foo.stubs(:find).with(1).returns @foo
@@ -30,43 +30,43 @@ class DynamicPaperclip::AttachmentStyleGeneratorTest < MiniTest::Unit::TestCase
     @attachment.expects(:exists?).with(:dynamic_42x42).returns(true)
     @attachment.expects(:process_dynamic_style).never
 
-    get '/system/foos/images/1/dynamic_42x42/file', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
+    get '/system/foos/images/1/dynamic_42x42/rails.png', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
   end
 
   should 'process style if it is dynamic and does not exist' do
     @attachment.expects(:exists?).with(:dynamic_42x42).returns(false)
     @attachment.expects(:process_dynamic_style).once
 
-    get '/system/foos/images/1/dynamic_42x42/file', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
+    get '/system/foos/images/1/dynamic_42x42/rails.png', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
   end
 
   should 'find record when an ID is used' do
     Foo.expects(:find).with(1).returns @foo
 
-    get '/system/foos/images/1/dynamic_42x42/file', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
+    get '/system/foos/images/1/dynamic_42x42/rails.png', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
   end
 
   should 'find record when an ID partition is used' do
     @foo.stubs(:image_with_id_partition_in_url).returns @attachment
     Foo.expects(:find).with(10042).returns @foo
 
-    get '/system/foos/image_with_id_partition_in_urls/000/010/042/dynamic_42x42/file', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
+    get '/system/foos/image_with_id_partition_in_urls/000/010/042/dynamic_42x42/rails.png', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
   end
 
   should 'respond with correct content type' do
-    get '/system/foos/images/1/dynamic_42x42/file', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
+    get '/system/foos/images/1/dynamic_42x42/rails.png', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
 
     assert_equal 'image/jpeg', last_response.header['Content-Type']
   end
 
   should 'respond with correct content-disposition' do
-    get '/system/foos/images/1/dynamic_42x42/file', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
+    get '/system/foos/images/1/dynamic_42x42/rails.png', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
 
     assert_equal 'inline; filename=rails.png', last_response.header['Content-Disposition']
   end
 
   should 'respond with correct content-transfer-encoding' do
-    get '/system/foos/images/1/dynamic_42x42/file', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
+    get '/system/foos/images/1/dynamic_42x42/rails.png', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
 
     assert_equal 'binary', last_response.header['Content-Transfer-Encoding']
   end
@@ -75,19 +75,19 @@ class DynamicPaperclip::AttachmentStyleGeneratorTest < MiniTest::Unit::TestCase
     file_body = ActionController::DataStreaming::FileBody.new(File.join(FIXTURES_DIR, 'rails.png'))
     ActionController::DataStreaming::FileBody.expects(:new).with(File.join(FIXTURES_DIR, 'rails.png')).returns(file_body)
 
-    response = app.call(Rack::MockRequest.env_for('/system/foos/images/1/dynamic_42x42/file?s='+DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42')))
+    response = app.call(Rack::MockRequest.env_for('/system/foos/images/1/dynamic_42x42/rails.png?s='+DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42')))
 
     assert_equal file_body, response[2]
   end
 
   should 'respond with success' do
-    get '/system/foos/images/1/dynamic_42x42/file', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
+    get '/system/foos/images/1/dynamic_42x42/rails.png', { s: DynamicPaperclip::UrlSecurity.generate_hash('dynamic_42x42') }
 
     assert last_response.ok?
   end
 
   should '403 with empty body if hash does not match style name' do
-    get '/system/foos/images/1/dynamic_42x42/file', { s: 'this is an invalid hash' }
+    get '/system/foos/images/1/dynamic_42x42/rails.png', { s: 'this is an invalid hash' }
 
     assert_equal 403, last_response.status
     assert_equal '', last_response.body


### PR DESCRIPTION
/dynamic_10x10/test-wrong-filename.jpg should return a 404 if the original filename is /original/test.jpg.