### PR TITLE
Fixed the 'There was an error processing the thumbnail for ...' error…

### DIFF
--- a/lib/dynamic_paperclip/style_naming.rb
+++ b/lib/dynamic_paperclip/style_naming.rb
@@ -13,7 +13,7 @@ module DynamicPaperclip
     # Reverse of #dynamic_style_name_from_definition,
     # given a dynamic style name, extracts the definition (style options)
     def self.style_definition_from_dynamic_style_name(name)
-      CGI.unescape name[8..-1]
+      CGI.unescape(name[8..-1]).split(/_/).first
     end
   end
 end


### PR DESCRIPTION
… when editing an image already generated.

This occurred when we re-upload an image which has already been process by this gem and is using "#" in the size (ex: 800x800#). This was caused by the "style_definition_from_dynamic_style_name" function which was not parsing the style name accurately (ex: dynamic_800x800#_test -> 800x800#_test, instead of 800x800#). Because of that, Paperclip was not able to catch the special # geometry arg and the resize option (800x800#) was sent to the imagemagick convert function, which raised error: invalid argument for option `-resize':  800x800#